### PR TITLE
Remove Bookmarks section from other user's profile

### DIFF
--- a/src/components/Profile.jsx
+++ b/src/components/Profile.jsx
@@ -147,7 +147,7 @@ export function Profile({
         </div>
       </header>
       <main className="mt-4">
-        <Outlet context={{ _id, bookmarks, likes }} />
+        <Outlet context={{ _id, bookmarks, likes, isCurrentUserProfile }} />
       </main>
       <Modal childName={`${username}_followersList`}>
         <UsersList listTitle="Followers" userIds={followers} />

--- a/src/components/ProfilePosts.jsx
+++ b/src/components/ProfilePosts.jsx
@@ -11,7 +11,7 @@ import { Post, SkeletonLoader } from "components";
 export function ProfilePosts() {
   const { pathname } = useLocation();
   const { username } = useParams();
-  const { _id, bookmarks, likes } = useOutletContext();
+  const { _id, bookmarks, likes, isCurrentUserProfile } = useOutletContext();
   const { status } = useSelector((state) => state.posts);
   const userPosts = useSelector((state) => getUserPosts(state, _id));
   const userLikes = useSelector((state) => getUserLikes(state, likes || []));
@@ -53,6 +53,9 @@ export function ProfilePosts() {
     <section className="flex flex-col gap-4 p-4">
       <div className="flex gap-2">
         {profileSectionButtons.map(({ type, path, key }) => {
+          if(!isCurrentUserProfile && type==="Bookmarks" ){
+            return ''
+          }
           return (
             <Link
               key={key}

--- a/src/components/ProfilePosts.jsx
+++ b/src/components/ProfilePosts.jsx
@@ -14,11 +14,11 @@ export function ProfilePosts() {
   const { _id, bookmarks, likes, isCurrentUserProfile } = useOutletContext();
   const { status } = useSelector((state) => state.posts);
   const userPosts = useSelector((state) => getUserPosts(state, _id));
-  const userLikes = useSelector((state) => getUserLikes(state, likes || []));
+  const userLikes = useSelector((state) => getUserLikes(state, likes ?? []));
   const userBookmarks = useSelector((state) =>
     getUserBookmarks(state, bookmarks ?? [])
   );
-  const postTypes = {
+  const allTypesOfPosts = {
     "": userPosts,
     likes: userLikes,
     bookmarks: userBookmarks,
@@ -27,7 +27,7 @@ export function ProfilePosts() {
     username === undefined
       ? pathname.slice(9)
       : pathname.slice(10 + username.length);
-  const postsToShow = postTypes[postTypeToShow];
+  const postsToShow = allTypesOfPosts[postTypeToShow];
   const arePostsLoading =
     (status.type === "getAllPosts" && status.value === "pending") ||
     postsToShow === undefined;
@@ -49,11 +49,12 @@ export function ProfilePosts() {
     },
   ];
   const isLinkActive = (path) => path === pathname;
+  const shouldHideBookmarks = !isCurrentUserProfile;
   return (
     <section className="flex flex-col gap-4 p-4">
       <div className="flex gap-2">
         {profileSectionButtons.map(({ type, path, key }) => {
-          if(!isCurrentUserProfile && type==="Bookmarks" ){
+          if(shouldHideBookmarks && type==="Bookmarks"){
             return ''
           }
           return (

--- a/src/routing/AllRoutes.jsx
+++ b/src/routing/AllRoutes.jsx
@@ -32,7 +32,6 @@ export function AllRoutes() {
         <Route path="/profile/:username" element={<CommonUserProfile />}>
           <Route path="" element={<ProfilePosts />} />
           <Route path="likes" element={<ProfilePosts />} />
-          <Route path="bookmarks" element={<ProfilePosts />} />
         </Route>
         <Route path="/explore" element={<Explore />} />
       </Route>

--- a/src/slices/postsSlice.js
+++ b/src/slices/postsSlice.js
@@ -225,7 +225,7 @@ export const getUserPosts = (state, userId) => {
 
 export const getUserBookmarks = (state, bookmarkedPostIds) => {
   const bookmarkedPosts = bookmarkedPostIds
-    .map((id) => state.posts.allPosts.find((post) => post._id === id) ?? {})
+    .map((id) => state.posts.allPosts.find((post) => post._id === id))
     .reverse();
   return bookmarkedPosts;
 };


### PR DESCRIPTION
## Overview
- Remove bookmarks section from other user's profile so that the current user can only see their bookmarks
- Fix empty object error in bookmarks ; if a post was not found in the list then it was returning an empty object that rendered an empty post with no content and no user 
- Renamed some variables for better readability